### PR TITLE
Add `texlab.build.filename` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,11 @@
             "default": ".",
             "description": "Directory containing the output file."
           },
+          "texlab.build.filename": {
+            "type": "string",
+            "default": null,
+            "description": "The base name of the output file."
+          },
           "texlab.forwardSearch.executable": {
             "type": [
               "string",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
           "texlab.build.pdfDirectory": {
             "type": "string",
             "default": ".",
-            "description": "Directory containing the build log files."
+            "description": "Directory containing the output file."
           },
           "texlab.forwardSearch.executable": {
             "type": [


### PR DESCRIPTION
<code>VSCode</code> indicates <code>texlab.build.filename</code> as an unknown configuration setting, despite being supported by [<code>TexLab</code>](https://github.com/latex-lsp/texlab/blob/75efe5c4502527f8cbf28e4b93ae881333d46301/crates/texlab/src/server/options.rs#L73). This PR fixes this issue.