### PR TITLE
Add `texlab.findEnvironments` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The changelog of the TexLab language server can be found [here](https://github.c
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Current
+
+### Changed
+
+- Add the `texlab.findEnvironments` command
+- Add the `texlab.build.filename` setting
+
 ## [5.21.0] - 2024-10-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -357,6 +357,12 @@
         "category": "LaTeX"
       },
       {
+        "command": "latex.findEnvironments",
+        "title": "Find environments",
+        "description": "Returns a list of all environments that contain the cursor position.",
+        "category": "LaTeX"
+      },
+      {
         "command": "latex.showDependencyGraph",
         "title": "Show dependency graph",
         "description": "Visualizes the dependencies of all files currently loaded.",
@@ -383,6 +389,10 @@
         },
         {
           "command": "latex.changeEnvironment",
+          "when": "editorLangId =~ /(latex|bibtex)/"
+        },
+        {
+          "command": "latex.findEnvironments",
           "when": "editorLangId =~ /(latex|bibtex)/"
         },
         {

--- a/src/client.ts
+++ b/src/client.ts
@@ -129,6 +129,26 @@ export class CustomProgressFeature implements StaticFeature {
   }
 }
 
+class EnvironmentName {
+  text: string;
+  range: vscode.Range;
+
+  constructor(text: string, range: vscode.Range) {
+    this.text = text;
+    this.range = range;
+  }
+}
+
+export class Environment {
+  name: EnvironmentName;
+  fullRange: vscode.Range;
+
+  constructor(name: EnvironmentName, fullRange: vscode.Range) {
+    this.name = name;
+    this.fullRange = fullRange;
+  }
+}
+
 export class LatexLanguageClient extends LanguageClient {
   constructor(
     name: string,
@@ -187,6 +207,22 @@ export class LatexLanguageClient extends LanguageClient {
             this.code2ProtocolConverter.asTextDocumentIdentifier(document),
           position,
           newName,
+        },
+      ],
+    });
+  }
+
+  public async findEnvironments(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): Promise<Environment[]> {
+    return await this.sendRequest(ExecuteCommandRequest.type, {
+      command: 'texlab.findEnvironments',
+      arguments: [
+        {
+          textDocument:
+            this.code2ProtocolConverter.asTextDocumentIdentifier(document),
+          position,
         },
       ],
     });


### PR DESCRIPTION
[VS Code API](https://code.visualstudio.com/api/references/vscode-api) provides different forms of notifications, panels, and popup menus that could be used to report environments that contain the cursor's position. This PR suggests using <code>showQuickPick</code> to allow the user to select the environment. Upon selection, the cursor is moved to the beginning of the environment.